### PR TITLE
Removed `uname -p` to fix build on Gentoo.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -956,12 +956,7 @@ AC_SUBST(PTHREAD_LIBS)
 AC_SUBST(PTHREAD_CFLAGS)
 #
 # Check for additional features for this hardware.
-# Check whether we have a processor type. If not, set to
-# "unknown" and check for uname -m.
-HARDWARE=`(uname -p) 2>/dev/null || echo unknown`
-if test "$HARDWARE" = "unknown"; then
-   HARDWARE=`(uname -m) 2>/dev/null || echo unknown`
-fi
+HARDWARE=`(uname -m) 2>/dev/null || echo unknown`
 #
 # For hysterical raisons, "sparc" is kept here as "sun4u" Yuck.
 if test "$HARDWARE" = "sparc"; then


### PR DESCRIPTION
`uname -p` is not portable and behaves differently between implementations.
On Gentoo, coreutils is patched (003_all_coreutils-gentoo-uname.patch) to acquire processor information from `/proc/cpuinfo` and generate strings like `Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz`, breaking the build.

To be able to `./configure`, other autotools-generated files should be added too.
